### PR TITLE
compiles failed with strlen not known on kubuntu

### DIFF
--- a/src/Tensorflow2/testtf2.cpp
+++ b/src/Tensorflow2/testtf2.cpp
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h> 
 #include <math.h> 
+#include <cstring>
 #include <vector>
 
 #include "tensorflow2.h"


### PR DESCRIPTION
initialize.sh failed at compiling at ~23% because of strlen not being known. Adding #include <cstring>

btw. I'm a github noob. Just wanted to help get this fixed. Feel free to discard this pull request if it is the wrong process, and perform the fix yourself. 